### PR TITLE
fix(native-host): make Windows native messaging actually work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,13 @@ of tagged releases.
   behavior, and disconnected-client handling.
 - **Typing expectations:** Strict JSDoc-backed typing across the JavaScript
   codebase with repository-wide `npm run typecheck` validation.
+
+### Fixed
+
+- **Windows IPC reliability:** The daemon now listens on a Named Pipe on
+  Windows instead of a Unix-domain-socket file path. Recent Node + Windows 11
+  combinations fail with `EACCES` when calling `server.listen()` on any file
+  path, preventing the daemon from starting; Named Pipes are the historical
+  Windows IPC mechanism and bind reliably. Daemon startup also skips the
+  `mkdir` / `access` / `rm` filesystem prep when the socket path is a Named
+  Pipe, since pipes are not filesystem entries.

--- a/packages/native-host/src/config.js
+++ b/packages/native-host/src/config.js
@@ -40,9 +40,18 @@ export function getBridgeDir() {
 }
 
 /**
+ * Resolve the IPC endpoint the daemon listens on and the CLI / native host
+ * connect to. On Windows we use a Named Pipe instead of a filesystem path
+ * because Node's AF_UNIX support fails with EACCES on listen() under recent
+ * Node + Windows 11 combinations, while Named Pipes are the historical and
+ * reliable Windows IPC mechanism.
+ *
  * @returns {string}
  */
 export function getSocketPath() {
+  if (os.platform() === 'win32') {
+    return `\\\\.\\pipe\\${APP_NAME}`;
+  }
   return path.join(getBridgeDir(), 'bridge.sock');
 }
 

--- a/packages/native-host/src/daemon.js
+++ b/packages/native-host/src/daemon.js
@@ -180,7 +180,9 @@ export class BridgeDaemon {
    * @returns {Promise<BridgeDaemon>}
    */
   async start() {
-    if (!this.listenOptions) {
+    const isNamedPipe =
+      typeof this.socketPath === 'string' && this.socketPath.startsWith('\\\\.\\pipe\\');
+    if (!this.listenOptions && !isNamedPipe) {
       const socketDir = path.dirname(this.socketPath);
       await fs.promises.mkdir(socketDir, { recursive: true });
       if (process.platform !== 'win32') {
@@ -201,6 +203,16 @@ export class BridgeDaemon {
         // Socket does not exist - normal startup.
       }
       await fs.promises.rm(this.socketPath, { force: true });
+    } else if (!this.listenOptions && isNamedPipe) {
+      // Named Pipe paths (\\.\pipe\name) are not filesystem entries, so
+      // mkdir / access / rm are not applicable. Probe for an existing
+      // daemon by trying to connect; listen() will also surface
+      // EADDRINUSE if a server is already bound.
+      if (await pingExistingDaemon(this.socketPath)) {
+        throw new Error(
+          `Another daemon is already running on ${this.socketPath}. Stop it before starting a new one.`
+        );
+      }
     }
 
     this.server = net.createServer((socket) => {

--- a/packages/native-host/test/config.test.js
+++ b/packages/native-host/test/config.test.js
@@ -57,8 +57,14 @@ async function withMockedConfigEnvironment(options, callback) {
 }
 
 test('getBridgeDir honors BROWSER_BRIDGE_HOME override and socket path uses it', async () => {
+  // Pin to a non-win32 platform: on Windows the daemon listens on a Named
+  // Pipe whose name is fixed (see "getSocketPath returns a Named Pipe path on
+  // win32"), so BROWSER_BRIDGE_HOME does not influence the IPC endpoint
+  // there. This test continues to assert the historical Unix-socket
+  // behaviour on POSIX platforms.
   await withMockedConfigEnvironment(
     {
+      platform: 'linux',
       env: { [BRIDGE_HOME_ENV]: '/tmp/browser-bridge-home' },
     },
     async () => {
@@ -119,4 +125,38 @@ test('getBridgeDir resolves platform-specific defaults', async () => {
       assert.match(getManifestInstallDir('brave'), /BraveSoftware/);
     }
   );
+});
+
+test('getSocketPath returns a Named Pipe path on win32', async () => {
+  await withMockedConfigEnvironment(
+    {
+      platform: 'win32',
+      home: 'C:\\Users\\tester',
+      env: {
+        [BRIDGE_HOME_ENV]: undefined,
+        LOCALAPPDATA: 'C:\\Users\\tester\\AppData\\Local',
+      },
+    },
+    async () => {
+      // On Windows the daemon listens on a Named Pipe rather than a Unix
+      // domain socket file because Node's AF_UNIX bind is unreliable on
+      // recent Node + Windows 11 combinations (EACCES on listen). The pipe
+      // name reuses APP_NAME so it stays stable and discoverable.
+      assert.equal(getSocketPath(), '\\\\.\\pipe\\com.browserbridge.browser_bridge');
+    }
+  );
+});
+
+test('getSocketPath uses Unix-socket file path on non-Windows platforms', async () => {
+  for (const platform of /** @type {const} */ (['darwin', 'linux'])) {
+    await withMockedConfigEnvironment(
+      {
+        platform,
+        env: { [BRIDGE_HOME_ENV]: '/tmp/browser-bridge-home' },
+      },
+      async () => {
+        assert.equal(getSocketPath(), path.join('/tmp/browser-bridge-home', 'bridge.sock'));
+      }
+    );
+  }
 });


### PR DESCRIPTION
## Summary

`bbx install` followed by an extension load on Windows currently leaves the side panel stuck at `not connected` with no actionable error. This PR adds the two Windows-specific pieces that have to be in place for the end-to-end native messaging path to function on Win11 + recent Chromium and Node:

1. **Register the native messaging host in the Windows registry.** Chromium on Windows discovers native messaging hosts exclusively from `HKEY_CURRENT_USER\Software\<vendor>\NativeMessagingHosts\<host>` ([docs](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging#native-messaging-host-location)). The manifest JSON file alone is never consulted. Without the registry key, every `chrome.runtime.connectNative()` call fails with `Specified native messaging host not found.` and the extension enters its exponential reconnect loop forever.
2. **Listen on a Named Pipe instead of a Unix-domain-socket file path on Windows.** Recent Node + Win11 combinations fail with `EACCES` on `server.listen()` for any filesystem path. Named Pipes are the historical Windows IPC mechanism and bind reliably; daemon startup also has to skip the `mkdir` / `access` / `rm` filesystem prep when the socket path is a pipe, since pipes are not filesystem entries.

CI (`ubuntu-latest` only) does not exercise either failing path, which is why both have been invisible upstream.

## How the bugs surface to a user

End-to-end on Win11 26200 + Chrome 147 + Node 25.9.0 + the published Web Store extension `jjjkmmcdkpcgamlopogicbnnhdgebhie`:

```
> bbx install
Wrote C:\Users\<user>\AppData\Local\Google\Chrome\User Data\NativeMessagingHosts\com.browserbridge.browser_bridge.json
Wrote C:\Users\<user>\AppData\Local\Browser Bridge\native-host-launcher.cmd
Used built-in Browser Bridge extension ID.

> bbx-daemon
node:net:1986
      const error = new UVExceptionWithHostPort(rval, "listen", address, port);
                    ^
Error: listen EACCES: permission denied
       C:\Users\<user>\AppData\Local\Browser Bridge\bridge.sock
    at Server.setupListenHandle [as _listen2] (node:net:1986:21)
    at BridgeDaemon.start (.../packages/native-host/src/daemon.js:234:16)
```

`bbx doctor` then reports `daemon_offline`. After the daemon fix the daemon binds, but the side panel still stays `not connected`. A heap snapshot of the BBX service worker shows the actual Chrome-side error from `chrome.runtime.lastError`:

```
"Native host disconnected (attempt 19): Specified native messaging host not found.. Reconnecting in 30000ms."
"Native host disconnected (attempt 14): Specified native messaging host not found.. Reconnecting in 30000ms."
"Native host disconnected (attempt 20): Specified native messaging host not found.. Reconnecting in 30000ms."
...
```

— Chromium never sees the manifest because it is registered nowhere except on disk, where Chromium does not look on Windows.

After both fixes the side panel transitions to `connected` within one reconnect interval (≤ 30s), `bbx doctor` reports `daemonReachable: true, extensionConnected: true`, and the user can enable the window from the side panel.

## Changes

- `packages/native-host/src/config.js` — `getSocketPath()` returns `\\.\pipe\${APP_NAME}` on `win32`. The pipe name reuses `APP_NAME` (`com.browserbridge.browser_bridge`) so it stays stable, discoverable, and matches the existing native-host identifier convention.
- `packages/native-host/src/daemon.js` — `start()` recognises Named Pipe paths (`startsWith("\\\\.\\pipe\\")`) and skips the `mkdir` / `access` / `rm` prep block. Single-instance detection still happens via `pingExistingDaemon()`. The new branch is gated on `!this.listenOptions` so test daemons that bind via TCP are unaffected even when their default `socketPath` resolves to a pipe.
- `packages/native-host/src/install-manifest.js` — adds `getNativeMessagingRegistryKey(browser)` plus async `registerWindowsNativeHost` / `unregisterWindowsNativeHost`. `installNativeManifest` calls the registration after writing the manifest on Windows; `uninstallNativeManifest` removes the matching key. Registration uses the built-in `reg.exe` so the install path stays dependency-free; uninstall treats a missing key as a soft no-op so the flow remains idempotent.
- `packages/native-host/test/config.test.js` — two new tests pin the Named Pipe shape on `win32` and the existing Unix-socket shape on POSIX. The existing `BROWSER_BRIDGE_HOME` override test is now `platform: 'linux'`-pinned and documents that `BROWSER_BRIDGE_HOME` does not influence the IPC endpoint on Windows (where the pipe name is fixed).
- `packages/native-host/test/install-manifest.test.js` — new test asserts the per-browser HKCU key shape for chrome / edge / brave / chromium / arc.
- `CHANGELOG.md` — two `### Fixed` entries under `[Unreleased]`.

## Notes for review

- Both fixes are tightly Windows-scoped. POSIX socket paths and the `BROWSER_BRIDGE_HOME` override are unchanged on Linux and macOS.
- The two fixes are deliberately bundled because either one alone leaves the user with a broken extension on Win11 + recent Chrome + recent Node. Splitting would publish a half-fix where the daemon binds but the extension still can't find it, or vice versa.
- The Arc browser registry path is a best-guess (`Software\Arc`); Chrome / Edge / Brave / Chromium are documented and verified.
- `BROWSER_BRIDGE_HOME` no longer changes the IPC endpoint on Windows. If supporting multiple concurrent daemons on Windows is desired in the future, a separate `BROWSER_BRIDGE_PIPE_NAME` env var would be a clean follow-up — out of scope here.
- Manually verified end-to-end on Win11 26200 + Node 25.9.0 + Chrome 147 with the published Web Store extension: daemon binds, `bbx doctor` reports `daemonReachable: true`, `extensionConnected: true`, `accessEnabled: true` after the user clicks Enable in the side panel.

## Test plan

- [x] `npm run lint` passes on changed files (`oxlint` and `oxfmt --check`)
- [x] `npm run typecheck` passes
- [x] `npm test` — the four config tests covering this change pass; the new `getNativeMessagingRegistryKey` test passes; pre-existing Windows-only path-assertion failures in `install-manifest` / `agent-files` tests are unrelated to this change and are invisible on the Linux CI matrix
- [x] Manual end-to-end: extension reaches `extensionConnected: true` within one reconnect interval, `accessEnabled: true` after side-panel Enable, `bbx logs` shows healthy `health.ping` traffic