### PR TITLE
fix(cli): respect --tab flag in screenshot command

### DIFF
--- a/packages/agent-client/src/cli.js
+++ b/packages/agent-client/src/cli.js
@@ -618,16 +618,17 @@ async function main() {
     }
 
     if (command === 'screenshot') {
-      const [refOrSelector, outputPath] = rest;
-      if (!refOrSelector) throw new Error('Usage: screenshot <ref|selector> [path]');
-      const elementRef = await resolveRef(client, refOrSelector, null, REQUEST_SOURCE);
+      const parsed = extractTabFlag(rest);
+      const [refOrSelector, outputPath] = parsed.rest;
+      if (!refOrSelector) throw new Error('Usage: screenshot [--tab <tabId>] <ref|selector> [path]');
+      const elementRef = await resolveRef(client, refOrSelector, parsed.tabId, REQUEST_SOURCE);
       const response = await requestBridge(
         client,
         'screenshot.capture_element',
         {
           elementRef,
         },
-        { source: REQUEST_SOURCE }
+        { tabId: parsed.tabId, source: REQUEST_SOURCE }
       );
       if (!response.ok) {
         await printSummary(response);

--- a/packages/agent-client/src/command-registry.js
+++ b/packages/agent-client/src/command-registry.js
@@ -346,7 +346,7 @@ export const CLI_HELP_SECTIONS = Object.freeze([
   {
     title: 'Capture',
     lines: [
-      'bbx screenshot <ref|selector> [path]                               Capture partial element screenshot',
+      'bbx screenshot [--tab <tabId>] <ref|selector> [path]               Capture partial element screenshot',
     ],
   },
 ]);


### PR DESCRIPTION
## Summary

The \`screenshot\` command reads positional args directly without first extracting \`--tab\`, so \`bbx screenshot --tab <id> <selector> [path]\` parses \`--tab\` as the ref/selector and the tabId as the output path — silently saving the screenshot to a file literally named \`--tab\` in the current directory.

## Repro

\`\`\`
bbx screenshot --tab 12345 ".prose"
# expected: capture .prose on tab 12345
# actual:   tries to resolveRef("--tab"), saves PNG to ./12345
\`\`\`

## Fix

Use the existing \`extractTabFlag(rest)\` helper, matching the idiom already in \`cdp-press-key\` (cli.js:601) and \`call\` (cli.js:792). The tabId is then forwarded to both \`resolveRef\` and \`requestBridge\` so an explicit \`--tab\` actually targets the requested tab. Help string in \`command-registry.js\` updated to surface the \`[--tab <tabId>]\` option.

Discovered while building chatui-bridge (a per-window Grok/Claude/etc adapter layer over BBX); my agent ran \`bbx screenshot --tab \$ID …\` and the screenshot ended up at \`C:/Users/Administrator/--tab\`.

## Test plan

- [ ] \`bbx screenshot --tab <id> <selector>\` — saves to default tmpdir path, captures the right tab
- [ ] \`bbx screenshot --tab <id> <selector> ./out.png\` — saves to ./out.png
- [ ] \`bbx screenshot <selector>\` — unchanged behavior (uses default active tab)