### PR TITLE
cli: honor --tab flag + retry-on-stale for shortcut commands

### DIFF
--- a/packages/agent-client/src/cli.js
+++ b/packages/agent-client/src/cli.js
@@ -587,18 +587,41 @@ async function main() {
       // the ref must be resolved against the SAME tab the action targets,
       // so we pass tabId to both resolveRef and the subsequent request.
       const { tabId, rest: shortcutArgs } = extractTabFlag(rest);
-      let elementRef;
-      if (shortcutCmd.resolve) {
-        if (!shortcutArgs[0]) throw new Error(`Usage: ${command} <ref|selector>`);
-        elementRef = await resolveRef(client, shortcutArgs[0], tabId, REQUEST_SOURCE);
+      const selectorInput = shortcutCmd.resolve ? shortcutArgs[0] : null;
+      if (shortcutCmd.resolve && !selectorInput) {
+        throw new Error(`Usage: ${command} <ref|selector>`);
       }
-      const response = await requestBridge(
-        client,
-        shortcutCmd.method,
-        shortcutCmd.build(shortcutArgs, elementRef),
-        { source: REQUEST_SOURCE, tabId }
-      );
-      await printSummary(response, shortcutCmd.printMethod);
+
+      // Retry-on-stale: if the action fails with ELEMENT_STALE and the
+      // original input was a selector (not an el_xxx ref), re-resolve the
+      // selector and retry once. This handles the common case where the
+      // agent resolved an element, then the page re-rendered (React
+      // reconciliation, SPA navigation) before the action was dispatched.
+      const canRetry = typeof selectorInput === 'string' && !selectorInput.startsWith('el_');
+      const maxAttempts = canRetry ? 2 : 1;
+      /** @type {import('./runtime.js').BridgeResponse | undefined} */
+      let response;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        let elementRef;
+        if (shortcutCmd.resolve && selectorInput) {
+          elementRef = await resolveRef(client, selectorInput, tabId, REQUEST_SOURCE);
+        }
+        response = await requestBridge(
+          client,
+          shortcutCmd.method,
+          shortcutCmd.build(shortcutArgs, elementRef),
+          { source: REQUEST_SOURCE, tabId }
+        );
+        const errorText = !response.ok ? String(response.error?.message ?? '') : '';
+        const isStale = /stale/i.test(errorText);
+        if (isStale && attempt < maxAttempts) {
+          process.stderr.write(
+            `bbx: ELEMENT_STALE on "${selectorInput}", re-resolving and retrying...\n`
+          );
+        }
+        if (!isStale || attempt >= maxAttempts) break;
+      }
+      if (response) await printSummary(response, shortcutCmd.printMethod);
       return;
     }
 

--- a/packages/agent-client/src/cli.js
+++ b/packages/agent-client/src/cli.js
@@ -580,16 +580,23 @@ async function main() {
 
     const shortcutCmd = SHORTCUT_COMMANDS[command];
     if (shortcutCmd) {
+      // Allow `bbx <shortcut> --tab <id> ...` to target a specific tab.
+      // Without this, --tab gets eaten as a positional argument and the
+      // request hits whatever tab the bridge route happens to be pointing
+      // at (typically the active tab). For element-resolving shortcuts
+      // the ref must be resolved against the SAME tab the action targets,
+      // so we pass tabId to both resolveRef and the subsequent request.
+      const { tabId, rest: shortcutArgs } = extractTabFlag(rest);
       let elementRef;
       if (shortcutCmd.resolve) {
-        if (!rest[0]) throw new Error(`Usage: ${command} <ref|selector>`);
-        elementRef = await resolveRef(client, rest[0], null, REQUEST_SOURCE);
+        if (!shortcutArgs[0]) throw new Error(`Usage: ${command} <ref|selector>`);
+        elementRef = await resolveRef(client, shortcutArgs[0], tabId, REQUEST_SOURCE);
       }
       const response = await requestBridge(
         client,
         shortcutCmd.method,
-        shortcutCmd.build(rest, elementRef),
-        { source: REQUEST_SOURCE }
+        shortcutCmd.build(shortcutArgs, elementRef),
+        { source: REQUEST_SOURCE, tabId }
       );
       await printSummary(response, shortcutCmd.printMethod);
       return;


### PR DESCRIPTION
Two related CLI improvements for shortcut commands (`bbx click`, `focus`, `type`, `hover`, etc.):

## 1. Honor `--tab` flag (commit 1)

Shortcut commands silently dropped `--tab <id>` — the flag fell through as a positional argument. The request always hit the default routed tab instead of the explicit target.

**Fix:** Route shortcut commands through `extractTabFlag` (same as `bbx call` and `bbx cdp-press-key`), and pass `tabId` to both `resolveRef` and `requestBridge`.

## 2. Retry on ELEMENT_STALE (commit 2)

When a shortcut is given a CSS selector (not an `el_xxx` ref) and the action returns `ELEMENT_STALE`, the CLI now automatically re-resolves the selector against the current DOM and retries once.

This handles the common agent pattern where a page re-renders (React reconciliation, SPA navigation) between element resolution and action dispatch. Without this, agents must manually detect the stale error, re-query, and retry.

**Safety:**
- Only retries for selector-based inputs (raw `el_xxx` refs skip retry — no selector to re-resolve from)
- At most 1 retry
- Logs `bbx: ELEMENT_STALE on "<selector>", re-resolving and retrying...` to stderr on retry

## Why one PR

Commit 2 depends on commit 1's `extractTabFlag` integration in the shortcut path. They can't be split into independent PRs without duplicating the refactor.

## Test plan

- [ ] `npm test` passes
- [ ] Manual: `bbx click --tab <id> 'selector'` targets the explicit tab
- [ ] Manual: `bbx click 'selector'` without `--tab` uses the default (no behavior change)
- [ ] Manual: when page re-renders between resolve and click, selector-based click auto-retries instead of returning ELEMENT_STALE