### PR TITLE
cli: add --await and --tab flags to bbx eval

### DIFF
--- a/packages/agent-client/src/cli.js
+++ b/packages/agent-client/src/cli.js
@@ -665,18 +665,27 @@ async function main() {
     }
 
     if (command === 'eval') {
-      let expression = rest.join(' ');
+      const { tabId, rest: evalArgs } = extractTabFlag(rest);
+      // --await: wait for the result if the expression returns a Promise
+      const awaitIndex = evalArgs.indexOf('--await');
+      const awaitPromise = awaitIndex !== -1;
+      if (awaitIndex !== -1) evalArgs.splice(awaitIndex, 1);
+
+      let expression = evalArgs.join(' ');
       if (!expression || expression === '-') expression = await readStdin();
       if (!expression)
-        throw new Error('Usage: eval <expression>  (or pipe via stdin: echo "expr" | bbx eval -)');
+        throw new Error(
+          'Usage: eval [--tab <id>] [--await] <expression>  (or pipe via stdin: echo "expr" | bbx eval -)'
+        );
       const response = await requestBridge(
         client,
         'page.evaluate',
         {
           expression,
           returnByValue: true,
+          ...(awaitPromise ? { awaitPromise: true } : {}),
         },
-        { source: REQUEST_SOURCE }
+        { source: REQUEST_SOURCE, tabId }
       );
       await printSummary(response);
       return;

--- a/packages/agent-client/src/command-registry.js
+++ b/packages/agent-client/src/command-registry.js
@@ -294,7 +294,7 @@ export const CLI_HELP_SECTIONS = Object.freeze([
   {
     title: 'Page',
     lines: [
-      'bbx eval <expression>                                              Evaluate JS in page context (use - for stdin)',
+      'bbx eval [--await] <expression>                                     Evaluate JS in page context (--await for async, - for stdin)',
       ...[
         'console',
         'network',

--- a/packages/agent-client/test/cli-commands.test.ts
+++ b/packages/agent-client/test/cli-commands.test.ts
@@ -1166,6 +1166,6 @@ test('bbx eval with empty stdin reports the usage error', async () => {
   assert.equal(payload.evidence, null);
   assert.equal(
     payload.summary,
-    'ERROR: Usage: eval <expression>  (or pipe via stdin: echo "expr" | bbx eval -)'
+    'ERROR: Usage: eval [--tab <id>] [--await] <expression>  (or pipe via stdin: echo "expr" | bbx eval -)'
   );
 });


### PR DESCRIPTION
## Problem

\`page.evaluate\` at the protocol layer already supports \`awaitPromise\` (passes it to CDP \`Runtime.evaluate\`), but the \`bbx eval\` CLI command had no way to set it. Async IIFEs return \`{}\` (a Promise object serialized by value) instead of the resolved value.

## Fix

Add \`--await\` flag: \`bbx eval --await "fetch('/api').then(r => r.json())"\` waits for the Promise and returns the final value.

Also adds \`--tab\` support (same \`extractTabFlag\` pattern as other commands).

## Test plan
- [ ] \`bbx eval --await "new Promise(r => setTimeout(() => r(42), 500))"\` → \`{"value": 42, "type": "number"}\`
- [ ] \`bbx eval "1+1"\` still works without \`--await\` (no behavior change)
- [ ] \`bbx eval --tab <id> --await "..."\` targets the explicit tab