### PR TITLE
feat: add tabs.activate method

### DIFF
--- a/packages/agent-client/src/cli.js
+++ b/packages/agent-client/src/cli.js
@@ -476,6 +476,23 @@ async function main() {
       return;
     }
 
+    if (command === 'tab-activate') {
+      const [tabId] = rest;
+      if (!tabId) {
+        throw new Error('Usage: tab-activate <tabId>');
+      }
+      const response = await requestBridge(
+        client,
+        'tabs.activate',
+        {
+          tabId: parseIntArg(tabId, 'tabId'),
+        },
+        { source: REQUEST_SOURCE }
+      );
+      await printSummary(response);
+      return;
+    }
+
     if (command === 'call') {
       const { tabId, method, params } = await parseCallCommand(rest);
       const response = await requestBridge(client, method, params, {

--- a/packages/agent-client/src/command-registry.js
+++ b/packages/agent-client/src/command-registry.js
@@ -249,6 +249,7 @@ export const CLI_HELP_SECTIONS = Object.freeze([
       'bbx tabs                                                           List available tabs',
       'bbx tab-create [url]                                               Create a new tab',
       'bbx tab-close <tabId>                                              Close a tab',
+      'bbx tab-activate <tabId>                                           Bring a tab to the foreground',
       'bbx skill                                                          Runtime budget presets and method groups',
       'bbx mcp serve                                                      Start Browser Bridge as an MCP stdio server',
     ],

--- a/packages/extension/src/background.js
+++ b/packages/extension/src/background.js
@@ -400,6 +400,8 @@ async function dispatchBridgeRequest(request) {
       return handleCreateTab(request);
     case 'tabs.close':
       return handleCloseTab(request);
+    case 'tabs.activate':
+      return handleActivateTab(request);
     case 'page.evaluate':
       return handlePageEvaluate(request);
     case 'page.get_console':
@@ -541,6 +543,50 @@ async function handleCloseTab(request) {
   return createSuccess(
     request.id,
     { closed: true, tabId: params.tabId },
+    { method: request.method }
+  );
+}
+
+/**
+ * Bring a tab to the foreground (make it the active tab in its window).
+ * Useful for agents that need to focus a specific tab before performing
+ * debugger-backed operations or ensuring the tab is visible.
+ */
+/** @param {BridgeRequest} request */
+async function handleActivateTab(request) {
+  const tabId = request.params?.tabId;
+  if (typeof tabId !== 'number' || !Number.isFinite(tabId)) {
+    return createFailure(request.id, ERROR_CODES.INVALID_REQUEST, 'tabId is required.', null, {
+      method: request.method,
+    });
+  }
+  if (!state.enabledWindow) {
+    return createFailure(request.id, ERROR_CODES.ACCESS_DENIED, ACCESS_DENIED_WINDOW_OFF, null, {
+      method: request.method,
+    });
+  }
+  let tab;
+  try {
+    tab = await chrome.tabs.get(tabId);
+  } catch {
+    return createFailure(request.id, ERROR_CODES.TAB_MISMATCH, `Tab ${tabId} not found.`, null, {
+      method: request.method,
+    });
+  }
+  if (tab.windowId !== state.enabledWindow.windowId) {
+    return createFailure(
+      request.id,
+      ERROR_CODES.ACCESS_DENIED,
+      'Tab does not belong to the enabled window.',
+      null,
+      { method: request.method }
+    );
+  }
+  await chrome.tabs.update(tabId, { active: true });
+  await emitUiState();
+  return createSuccess(
+    request.id,
+    { activated: true, tabId, title: tab.title ?? '', url: tab.url ?? '' },
     { method: request.method }
   );
 }

--- a/packages/protocol/src/capabilities.js
+++ b/packages/protocol/src/capabilities.js
@@ -51,6 +51,7 @@ export const METHOD_CAPABILITIES = Object.freeze({
   'tabs.list': null,
   'tabs.create': CAPABILITIES.TABS_MANAGE,
   'tabs.close': CAPABILITIES.TABS_MANAGE,
+  'tabs.activate': CAPABILITIES.TABS_MANAGE,
   'skill.get_runtime_context': null,
   'setup.get_status': null,
   'setup.install': null,

--- a/packages/protocol/src/registry.js
+++ b/packages/protocol/src/registry.js
@@ -28,6 +28,7 @@ const BRIDGE_METHOD_DESCRIPTIONS = Object.freeze({
   'tabs.list': 'List tabs in the enabled window.',
   'tabs.create': 'Create a new tab in the enabled window.',
   'tabs.close': 'Close a tab in the enabled window.',
+  'tabs.activate': 'Bring a tab to the foreground in the enabled window.',
   'skill.get_runtime_context': 'Return runtime method groups, budgets, and limits.',
   'setup.get_status': 'Return MCP and skill setup status.',
   'setup.install': 'Install or uninstall MCP or skill integration targets.',
@@ -130,6 +131,7 @@ export const BRIDGE_METHOD_REGISTRY = Object.freeze({
   'tabs.list': createRegistryEntry('tabs.list', 'tabs', false, [], 'trivial'),
   'tabs.create': createRegistryEntry('tabs.create', 'tabs', false, ['url', 'active'], 'trivial'),
   'tabs.close': createRegistryEntry('tabs.close', 'tabs', false, ['tabId'], 'trivial'),
+  'tabs.activate': createRegistryEntry('tabs.activate', 'tabs', false, ['tabId'], 'trivial'),
   // page — low (basic reads), moderate (evaluate, debugger-backed)
   'page.get_state': createRegistryEntry('page.get_state', 'page', true, [], 'low'),
   'page.evaluate': {

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -37,6 +37,7 @@ export type BridgeMethod =
   | 'tabs.list'
   | 'tabs.create'
   | 'tabs.close'
+  | 'tabs.activate'
   | 'skill.get_runtime_context'
   | 'setup.get_status'
   | 'setup.install'


### PR DESCRIPTION
## Problem

Agents driving multi-tab workflows cannot programmatically switch the active tab. When the user or another operation changes the focused tab, agents lose the ability to perform CDP-backed operations (screenshots, key dispatch) on their target tab.

## Fix

New \`tabs.activate\` method across all layers:
- **Protocol**: \`tabs.activate\` (trivial budget, param: \`tabId\`)
- **Extension**: \`handleActivateTab\` — validates window scope, calls \`chrome.tabs.update(tabId, { active: true })\`
- **CLI**: \`bbx tab-activate <tabId>\`

Same security model as \`tabs.close\`: tab must belong to the enabled window.

## Test plan
- [ ] \`bbx tab-activate <tabId>\` brings the tab to foreground
- [ ] \`bbx tab-activate <wrong-window-tab>\` returns ACCESS_DENIED
- [ ] \`bbx tab-activate 999999\` returns TAB_MISMATCH