### PR TITLE
docs: clarify input.click param format in CLI help and skill

### DIFF
--- a/packages/agent-client/src/command-registry.js
+++ b/packages/agent-client/src/command-registry.js
@@ -261,6 +261,10 @@ export const CLI_HELP_SECTIONS = Object.freeze([
       "bbx batch '[{method,params,tabId?},...]'                           Parallel method calls",
       'Advanced bridge params stay available through `bbx call`, even when shortcuts expose only the common case.',
       'For open-ended investigation, start with `bbx batch` on `page.get_state`, `dom.query`, and `page.get_text` before any screenshot or CDP call.',
+      '',
+      'Interaction methods need a target wrapper (not a bare ref):',
+      '  bbx call input.click \'{"target":{"elementRef":"el_xxx"}}\'',
+      '  bbx call input.type  \'{"target":{"elementRef":"el_xxx"},"text":"hello"}\'',
     ],
   },
   {

--- a/skills/browser-bridge/SKILL.md
+++ b/skills/browser-bridge/SKILL.md
@@ -283,7 +283,15 @@ Every CLI shortcut command produces consistent `{ok, summary, evidence}` JSON. U
 ## CLI Raw Params Gotchas
 
 - Use `selector`, not `scope`, to narrow `dom.find_by_text` and `dom.find_by_role`.
-- Wrap interaction targets as `target: { elementRef }` or `target: { selector }`; `viewport.scroll` also uses the `target` wrapper for element scrolling.
+- Wrap interaction targets as `target: { elementRef }` or `target: { selector }`; `viewport.scroll` also uses the `target` wrapper for element scrolling. **Do not pass `ref` or `elementRef` at the top level** -- interaction methods require the nested `target` wrapper:
+  ```bash
+  # CORRECT
+  bbx call input.click '{"target":{"elementRef":"el_xxx"}}'
+  bbx call input.type  '{"target":{"elementRef":"el_xxx"},"text":"hello"}'
+  # WRONG -- will fail with "Target not found"
+  bbx call input.click '{"ref":"el_xxx"}'
+  bbx call input.click '{"elementRef":"el_xxx"}'
+  ```
 - `input.drag` uses `source`, `destination`, and optional destination offsets `offsetX` / `offsetY`.
 - Raw `screenshot.capture_region` and `screenshot.capture_full_page` return base64 JSON; prefer `bbx screenshot <ref> [outPath]` when one element is enough.
 

--- a/skills/browser-bridge/references/interaction.md
+++ b/skills/browser-bridge/references/interaction.md
@@ -263,6 +263,24 @@ bbx call page.wait_for_load_state '{"timeoutMs":10000}'
 
 Use after clicking navigation links.
 
+## Raw `bbx call` for Interaction Methods
+
+All interaction methods (`input.click`, `input.type`, `input.focus`, `input.hover`, etc.) require the target wrapped in a `target` object -- do not pass `ref` or `elementRef` at the top level:
+
+```bash
+# CORRECT
+bbx call input.click '{"target":{"elementRef":"el_xxx"}}'
+bbx call input.click '{"target":{"elementRef":"el_xxx"},"button":"right"}'
+bbx call input.type  '{"target":{"elementRef":"el_xxx"},"text":"hello"}'
+bbx call input.focus '{"target":{"selector":"#search-input"}}'
+
+# WRONG -- "Target not found"
+bbx call input.click '{"ref":"el_xxx"}'
+bbx call input.click '{"elementRef":"el_xxx"}'
+```
+
+The CLI shortcuts (`bbx click el_xxx`) handle this wrapping automatically, but `bbx call` passes params as-is.
+
 ## Interaction Flow
 
 1. **Find target**: `dom.find_by_text`, `dom.find_by_role`, or `dom.query` → get `elementRef`


### PR DESCRIPTION
## Summary
- Clarify that `bbx call input.click` requires `{"target":{"elementRef":"..."}}` format, not `{"ref":"..."}` or `{"elementRef":"..."}`
- Add correct/wrong examples to CLI help, SKILL.md, and interaction reference
- CLI shortcuts (`bbx click el_xxx`) handle wrapping automatically but `bbx call` does not — this was a common source of "Target not found" errors

## Changes
- `packages/agent-client/src/command-registry.js` — Added examples to Generic RPC help section
- `skills/browser-bridge/SKILL.md` — Expanded target wrapper bullet with code block
- `skills/browser-bridge/references/interaction.md` — New "Raw bbx call" section with correct/wrong examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)